### PR TITLE
Updates on Profile Installation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "drupal/admin_toolbar": "^2.0",
         "drupal/adminimal_admin_toolbar": "^1.10",
         "drupal/adminimal_theme": "^1.5",
-        "drupal/apigee_api_catalog": "2.2",
+        "drupal/apigee_api_catalog": "^2.2",
         "drupal/apigee_edge": "^1.8",
         "drupal/backup_migrate": "^4.1",
         "drupal/better_exposed_filters": "^4.0@alpha",

--- a/config_update/install/core.entity_form_display.node.apidoc.default.yml
+++ b/config_update/install/core.entity_form_display.node.apidoc.default.yml
@@ -1,0 +1,117 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.apidoc.body
+    - field.field.node.apidoc.field_apidoc_fetched_timestamp
+    - field.field.node.apidoc.field_apidoc_file_link
+    - field.field.node.apidoc.field_apidoc_spec
+    - field.field.node.apidoc.field_apidoc_spec_file_source
+    - field.field.node.apidoc.field_apidoc_spec_md5
+    - field.field.node.apidoc.field_service_type_apidoc
+    - node.type.apidoc
+  module:
+    - file
+    - file_link
+    - path
+    - text
+id: node.apidoc.default
+targetEntityType: node
+bundle: apidoc
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 1
+    region: content
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+      show_summary: false
+    third_party_settings: {  }
+  created:
+    type: datetime_timestamp
+    weight: 7
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_apidoc_file_link:
+    type: file_link_default
+    weight: 4
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+  field_apidoc_spec:
+    weight: 3
+    settings:
+      progress_indicator: throbber
+    third_party_settings: {  }
+    type: file_generic
+    region: content
+  field_apidoc_spec_file_source:
+    weight: 2
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+  field_service_type_apidoc:
+    type: entity_reference_autocomplete
+    weight: 5
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 8
+    region: content
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 11
+    region: content
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 9
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 6
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+      match_limit: 10
+    region: content
+    third_party_settings: {  }
+hidden:
+  field_apidoc_fetched_timestamp: true
+  field_apidoc_spec_md5: true

--- a/config_update/install/core.entity_view_display.node.apidoc.cards.yml
+++ b/config_update/install/core.entity_view_display.node.apidoc.cards.yml
@@ -1,0 +1,59 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.cards
+    - field.field.node.apidoc.body
+    - field.field.node.apidoc.field_apidoc_fetched_timestamp
+    - field.field.node.apidoc.field_apidoc_file_link
+    - field.field.node.apidoc.field_apidoc_spec
+    - field.field.node.apidoc.field_apidoc_spec_file_source
+    - field.field.node.apidoc.field_apidoc_spec_md5
+    - field.field.node.apidoc.field_service_type_apidoc
+    - node.type.apidoc
+  module:
+    - smart_trim
+    - user
+id: node.apidoc.cards
+targetEntityType: node
+bundle: apidoc
+mode: cards
+content:
+  body:
+    type: smart_trim
+    weight: 0
+    region: content
+    label: hidden
+    settings:
+      trim_length: 78
+      trim_type: chars
+      trim_suffix: ' [...]'
+      wrap_class: trimmed
+      more_text: More
+      more_class: more-link
+      summary_handler: full
+      trim_options:
+        trim_zero: true
+        text: false
+      wrap_output: false
+      more_link: false
+    third_party_settings: {  }
+  field_service_type_apidoc:
+    type: entity_reference_label
+    weight: 1
+    region: content
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+  links:
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  field_apidoc_fetched_timestamp: true
+  field_apidoc_file_link: true
+  field_apidoc_spec: true
+  field_apidoc_spec_file_source: true
+  field_apidoc_spec_md5: true

--- a/config_update/install/core.entity_view_display.node.apidoc.default.yml
+++ b/config_update/install/core.entity_view_display.node.apidoc.default.yml
@@ -1,0 +1,53 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.apidoc.body
+    - field.field.node.apidoc.field_apidoc_fetched_timestamp
+    - field.field.node.apidoc.field_apidoc_file_link
+    - field.field.node.apidoc.field_apidoc_spec
+    - field.field.node.apidoc.field_apidoc_spec_file_source
+    - field.field.node.apidoc.field_apidoc_spec_md5
+    - field.field.node.apidoc.field_service_type_apidoc
+    - node.type.apidoc
+  module:
+    - apigee_api_catalog
+    - text
+    - user
+id: node.apidoc.default
+targetEntityType: node
+bundle: apidoc
+mode: default
+content:
+  body:
+    type: text_default
+    weight: 0
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  field_apidoc_spec:
+    weight: 2
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: apigee_api_catalog_smartdocs
+    region: content
+  field_service_type_apidoc:
+    type: entity_reference_label
+    weight: 1
+    region: content
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+  links:
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  field_apidoc_fetched_timestamp: true
+  field_apidoc_file_link: true
+  field_apidoc_spec_file_source: true
+  field_apidoc_spec_md5: true

--- a/config_update/install/field.field.node.apidoc.field_service_type_apidoc.yml
+++ b/config_update/install/field.field.node.apidoc.field_service_type_apidoc.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_service_type_apidoc
+    - node.type.apidoc
+    - taxonomy.vocabulary.service_type
+id: node.apidoc.field_service_type_apidoc
+field_name: field_service_type_apidoc
+entity_type: node
+bundle: apidoc
+label: 'Service Type'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      service_type: service_type
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config_update/install/field.storage.node.field_service_type_apidoc.yml
+++ b/config_update/install/field.storage.node.field_service_type_apidoc.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_service_type_apidoc
+field_name: field_service_type_apidoc
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config_update/install/views.view.apigee_api_catalog.yml
+++ b/config_update/install/views.view.apigee_api_catalog.yml
@@ -1,0 +1,446 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.cards
+    - field.storage.node.body
+    - node.type.apidoc
+    - system.menu.main
+    - taxonomy.vocabulary.service_type
+  module:
+    - better_exposed_filters
+    - node
+    - taxonomy
+    - text
+    - user
+    - views_infinite_scroll
+id: apigee_api_catalog
+label: 'API Catalog'
+module: views
+description: 'Display of the published APIs for the developers.'
+tag: ''
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: bef
+        options:
+          submit_button: Search
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+          text_input_required: 'Select any filter and click on Apply to see results'
+          text_input_required_format: basic_html
+          bef:
+            general:
+              autosubmit: true
+              autosubmit_exclude_textfield: false
+              autosubmit_textfield_delay: 500
+              autosubmit_hide: true
+              input_required: false
+              allow_secondary: false
+              secondary_label: 'Advanced options'
+              secondary_open: false
+            filter:
+              field_service_type_apidoc_target_id:
+                plugin_id: bef
+                advanced:
+                  rewrite:
+                    filter_rewrite_values: ''
+                  collapsible: false
+                  is_secondary: false
+                select_all_none: false
+                select_all_none_nested: false
+                display_inline: 0
+      pager:
+        type: infinite_scroll
+        options:
+          items_per_page: 3
+          offset: 0
+          id: 0
+          total_pages: null
+          tags:
+            previous: '‹ Previous'
+            next: 'Next ›'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          views_infinite_scroll:
+            button_text: 'Load More'
+            automatically_load_content: false
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: false
+      row:
+        type: 'entity:node'
+        options:
+          relationship: none
+          view_mode: cards
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          plugin_id: field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: h2
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        body:
+          id: body
+          table: node__body
+          field: body
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: text_summary_or_trimmed
+          settings:
+            trim_length: 600
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            apidoc: apidoc
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        field_service_type_apidoc_target_id:
+          id: field_service_type_apidoc_target_id
+          table: node__field_service_type_apidoc
+          field: field_service_type_apidoc_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_service_type_apidoc_target_id_op
+            label: 'Service Type'
+            description: ''
+            use_operator: false
+            operator: field_service_type_apidoc_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_service_type_target_id
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: true
+          type: select
+          limit: true
+          vid: service_type
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+      sorts:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          order: ASC
+          entity_type: node
+          entity_field: title
+          plugin_id: standard
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exposed: false
+          expose:
+            label: ''
+      title: 'API Catalog'
+      header: {  }
+      footer: {  }
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content:
+            value: 'No API documentation is currently available.'
+            format: basic_html
+          plugin_id: text
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+      use_ajax: true
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.body'
+  apidoc_list:
+    display_plugin: page
+    id: apidoc_list
+    display_title: Page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: apis
+      menu:
+        type: normal
+        title: 'API Catalog'
+        description: 'API Catalog'
+        expanded: false
+        parent: ''
+        weight: -49
+        context: '0'
+        menu_name: main
+        enabled: true
+      exposed_block: true
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.body'

--- a/sm_dev_portal.install
+++ b/sm_dev_portal.install
@@ -1,5 +1,7 @@
 <?php
 
+use Drupal\Component\Serialization\Yaml;
+
 /**
  * @file
  * Install, update and uninstall hooks for the Example Profile install profile.
@@ -58,4 +60,61 @@ function sm_dev_portal_install() {
   \Drupal::service('module_installer')->install(['sm_dev_portal_content'], TRUE);
   $config = \Drupal::configFactory()->getEditable('system.site');
   $config->set('page.front', '/node/1')->save();
+}
+
+/**
+ * Update to apigee_api_catalog 2.x.
+ */
+function sm_dev_portal_update_8009() {
+  $moduleHandler = \Drupal::moduleHandler();
+  if (!$moduleHandler->moduleExists('apigee_api_catalog')) {
+    return;
+  }
+
+  $configPath = drupal_get_path('profile', 'sm_dev_portal') . '/config/install';
+	$configPath_update = drupal_get_path('profile', 'sm_dev_portal') . '/config_update/install';
+
+	if ($moduleHandler->moduleExists('field')) {
+		$configToImports = [
+			'field.field.node.apidoc.field_service_type_apidoc',
+			'field.storage.node.field_service_type_apidoc',
+		];
+
+		foreach($configToImports as $configToImport) {
+			$raw = file_get_contents("$configPath_update/$configToImport.yml");
+			$data = Yaml::decode($raw);
+			\Drupal::configFactory()
+				->getEditable($configToImport)
+				->setData($data)
+				->save(TRUE);
+		}
+	}
+
+	if ($moduleHandler->moduleExists('apigee_api_catalog')) {
+		$configToImports = [
+			'core.entity_form_display.node.apidoc.default',
+			'core.entity_view_display.node.apidoc.default',
+			'core.entity_view_display.node.apidoc.cards',
+		];
+
+		foreach($configToImports as $configToImport) {
+			$raw = file_get_contents("$configPath_update/$configToImport.yml");
+			$data = Yaml::decode($raw);
+			\Drupal::configFactory()
+				->getEditable($configToImport)
+				->setData($data)
+				->save(TRUE);
+		}
+	}
+
+  if ($moduleHandler->moduleExists('views')) {
+    $configToImport = 'views.view.apigee_api_catalog';
+    $raw = file_get_contents("$configPath_update/$configToImport.yml");
+    $data = Yaml::decode($raw);
+    \Drupal::configFactory()
+      ->getEditable($configToImport)
+      ->setData($data)
+      ->save(TRUE);
+  }
+
 }


### PR DESCRIPTION
1. Prepare the installation profile to use Apigee API Catalog 2.x and above.
2. Added a hook_update_n to automate the setup of custom field (Service Type field) added on APIDoc Content type once installation profile update is initiated. Also included in the hook_update_n are Entity, Form and View Display configuration for the custom field: Service Type and as well as the configuration for Views: Apigee API Catalog.